### PR TITLE
feat: add `returnValidation` option to validate()

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ const config = { /* ... your webpack config */ }
 module.exports = validate(config, yourSchema)
 ```
 
+#### Advanced Usage
+If you need to access the validation results directly and want to control the side-effects (i.e. console.log output, `process.exit(1)` on fail behaviour) yourself, you can call the validation function like so: `validate(config, yourSchema, { returnValidation: true })`. This will make 1) the function return the validation results instead of your configuration and 2) not perform any side effects.
+
 #### Support
 Because this module uses the amazing `Joi` validation library, this module only supports Node >=4.0.0.
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-preset-es2015": "6.6.0",
     "babel-preset-stage-2": "6.5.0",
     "babel-register": "6.7.2",
+    "brace-expansion": "1.1.3",
     "codecov": "1.0.1",
     "commitizen": "^2.7.6",
     "compression-webpack-plugin": "0.3.1",

--- a/src/index.js
+++ b/src/index.js
@@ -48,8 +48,19 @@ const schema = Joi.object({
 
 
 // Easier consumability for require (default use case for non-transpiled webpack configs)
-module.exports = function validate(config, schema_ = schema) {
-  Joi.assert(config, schema_)
+module.exports = function validate(config, schema_ = schema, options = {}) {
+  const {
+    // Don't return the config object and throw on error, but just return the validation result
+    returnValidation, // bool
+  } = options
+
+  const validationResult = Joi.validate(config, schema_, { abortEarly: false })
+  if (returnValidation) return validationResult
+
+  if (validationResult.error) {
+    console.error(validationResult.error.annotate())
+    process.exit(1)
+  }
   console.info(chalk.green('[webpack-validator] Config is valid.'))
   return config
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -2,14 +2,46 @@ import sinon from 'sinon'
 import configs from '../test/passing-configs'
 import validate from './'
 
-before(() => {
-  !console.info.reset && sinon.stub(console, 'info')
-})
-
 describe('.', () => {
+  let sandbox
+  let processExitStub
+  let consoleInfoStub
+  let consoleErrorStub
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create()
+    consoleInfoStub = sandbox.stub(console, 'info')
+    consoleErrorStub = sandbox.stub(console, 'error')
+    processExitStub = sandbox.stub(process, 'exit')
+  })
+  afterEach(() => {
+    sandbox.restore()
+  })
+
   configs.forEach(({ config, name }) => {
     it(`validates ${name}`, () => {
       validate(config)
+
+      // The success message should have been printed
+      assert(consoleInfoStub.callCount === 1)
+
+      // The error message should not have been printed
+      if (consoleErrorStub.callCount !== 0) {
+        throw new Error(consoleErrorStub.args[0])
+      }
+      // process.exit should not have been called
+      assert(processExitStub.callCount === 0)
     })
+  })
+
+  it('for an invalid config the joi validation result is printed to console.error and ' +
+     'the process exits with exit code 1', () => {
+    const invalidConfig = { resolvee: 'bar' }
+    validate(invalidConfig)
+
+    // The error message should have been printed
+    assert(consoleErrorStub.callCount === 1)
+
+    // process.exit should have been called
+    assert(processExitStub.callCount === 1)
   })
 })

--- a/test/utils/allInvalid.js
+++ b/test/utils/allInvalid.js
@@ -11,30 +11,26 @@ export default (configs, schema) => {
         throw new Error('Pass data as `input` property')
       }
 
-      let result
-      try {
-        validate(invalidConfig, schema)
-      } catch (e) {
-        result = e
-      }
+      const result = validate(invalidConfig, schema, { returnValidation: true })
+      assert(result.error)
+      const { error } = result
+
       if (throwError) {
-        throw result
+        throw error
       }
 
-      assert(result)
+      assert(error)
       if (expectedError) {
         if (expectedError.path) {
-          assert(result.details[0].path === expectedError.path)
+          assert(error.details[0].path === expectedError.path)
         }
 
         if (expectedError.type) {
-          assert(result.details[0].type === expectedError.type)
+          assert(error.details[0].type === expectedError.type)
         }
 
         if (expectedError.message) {
-          // console.log(result.details[0].message)
-          // console.log(expectedError.message)
-          assert(result.details[0].message === expectedError.message)
+          assert(error.details[0].message === expectedError.message)
         }
       }
     })

--- a/test/utils/allValid.js
+++ b/test/utils/allValid.js
@@ -6,7 +6,8 @@ import validate from '../../src/index'
 export default (configs, schema) => {
   configs.forEach((validConfig, n) => {
     it(`valid #${n} should be valid`, () => {
-      validate(validConfig, schema)
+      const result = validate(validConfig, schema, { returnValidation: true })
+      assert(result.error === null)
     })
   })
 }


### PR DESCRIPTION
I integrated @nyrosmith's improved version of the `validate` function (it shows all validation results, not just the first) and added an option to the validate function, see updated `README.md` for description.
What do you think?