### PR TITLE
feat(webpack-dev-server): Support `stats` presets

### DIFF
--- a/src/properties/devServer/index.js
+++ b/src/properties/devServer/index.js
@@ -28,7 +28,10 @@ export default Joi.object({
   filename: notAbsolutePath,
   watchOptions: watchOptionsSchema,
   hot: Joi.boolean(),
-  stats: Joi.object(),
+  stats: Joi.alternatives().try([
+    Joi.object(),
+    Joi.string().valid(['none', 'errors-only', 'minimal', 'normal', 'verbose']),
+  ]),
   noInfo: Joi.boolean(),
   proxy: [
     Joi.object(),

--- a/src/properties/devServer/index.test.js
+++ b/src/properties/devServer/index.test.js
@@ -54,16 +54,26 @@ const validModuleConfigs = [
   // #24
   { stats: {} },
   // #25
-  { noInfo: true },
+  { stats: 'none' },
   // #26
-  { proxy: {} },
+  { stats: 'errors-only' },
   // #27
-  { proxy: 'http://proxy.url/' },
+  { stats: 'minimal' },
   // #28
-  { proxy: [] },
+  { stats: 'normal' },
   // #29
-  { staticOptions: {} },
+  { stats: 'verbose' },
   // #30
+  { noInfo: true },
+  // #31
+  { proxy: {} },
+  // #32
+  { proxy: 'http://proxy.url/' },
+  // #33
+  { proxy: [] },
+  // #34
+  { staticOptions: {} },
+  // #35
   { headers: {} },
 ]
 
@@ -77,6 +87,8 @@ const invalidModuleConfigs = [
   // #3
   { input: { stats: true } },
   // #4
+  { input: { stats: 'foobar' } },
+  // #5
   { input: { proxy: true } },
 ]
 


### PR DESCRIPTION
Webpack defines a few stats presets accessible through a string. Better allow those.

See https://github.com/webpack/webpack/blob/5b5775f9e2fc73fea46629f2d6a3ed7a1f8424d3/lib/Stats.js#L696-L730 and https://github.com/webpack/webpack/issues/1191 for further information.