### PR TITLE
feat(cli): Support `--all-scripts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ module.exports = validate(config, yourSchema)
 ```
 
 #### Quiet Mode
-If you want to mute console output apart from errors, set `--quiet` or `validate(config, yourSchema, {quiet: true})`. This is particularly useful if you are using webpack `--json` as you'll want to avoid writing additional text to the JSON output.
+If you want to mute console output apart from errors, set `--quiet` (`-q`) or `validate(config, yourSchema, {quiet: true})`. This is particularly useful if you are using webpack `--json` as you'll want to avoid writing additional text to the JSON output.
+
+#### Validate All **package.json** `scripts`
+It is possible to use the CLI to validate all your **package.json** `scripts` related configurations at once by using `--all-scripts` (`-a`). The system will try to guess the convention you are using and then executes validation against each script target based on that.
 
 #### Advanced Usage
 If you need to access the validation results directly and want to control the side-effects (i.e. console.log output, `process.exit(1)` on fail behaviour) yourself, you can call the validation function like so: `validate(config, yourSchema, { returnValidation: true })`. This will make 1) the function return the validation results instead of your configuration and 2) not perform any side effects.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint .",
     "cover": "nyc --reporter=lcov --reporter=text --reporter=html mocha src/**/*.test.js",
     "report-coverage": "cat ./coverage/lcov.info | node_modules/.bin/codecov",
-    "test": "mocha src/**/*.test.js",
+    "test": "mocha \"src/**/*.test.js\"",
     "watch:test": "npm run test -- -w",
     "release": "npm run build && with-package git commit -am pkg.version && with-package git tag pkg.version && git push && npm publish && git push --tags",
     "release:beta": "npm run release && npm run tag:beta",

--- a/src/bin/script-parsers.js
+++ b/src/bin/script-parsers.js
@@ -1,0 +1,32 @@
+export function webpackConfig(script) {
+  // Try to parse webpack config name. Not fool proof. Maybe
+  // there's a neater way.
+  const parts = script.split('--config')
+
+  if (parts.length > 1) {
+    // Pick the last part, trim and split to extract
+    return parts[parts.length - 1].trim().split(' ')[0]
+  }
+
+  return 'webpack.config.js'
+}
+
+export function nodeEnv(script) {
+  const parsedScript = script.indexOf('SET ') === 0 ?
+    script.split('SET ')[1] :
+    script
+
+  const parts = parsedScript.split('NODE_ENV=')
+
+  if (parts.length < 2) {
+    return ''
+  }
+
+  const ret = parts[1]
+
+  if (ret.indexOf('&&') >= 0) {
+    return ret.split('&&')[0].trim()
+  }
+
+  return ret.split(' ')[0].trim()
+}

--- a/src/bin/script-parsers.test.js
+++ b/src/bin/script-parsers.test.js
@@ -1,0 +1,29 @@
+import { webpackConfig, nodeEnv } from './script-parsers'
+
+describe('webpack config name parser', () => {
+  it('should parse --config', () => {
+    assert(
+      webpackConfig('NODE_ENV=development webpack --config demo.js') === 'demo.js'
+    )
+  })
+
+  it('should default to webpack.config.js', () => {
+    assert(
+      webpackConfig('webpack --profile --json > stats.json') === 'webpack.config.js'
+    )
+  })
+})
+
+describe('node env parser', () => {
+  it('should parse SET NODE_ENV', () => {
+    assert(nodeEnv('SET NODE_ENV=development&& webpack') === 'development')
+  })
+
+  it('should parse NODE_ENV', () => {
+    assert(nodeEnv('NODE_ENV=development webpack') === 'development')
+  })
+
+  it('should not parse invalid input', () => {
+    assert(nodeEnv('foobar') === '') // throw error instead?
+  })
+})

--- a/src/bin/validate-all-scripts.js
+++ b/src/bin/validate-all-scripts.js
@@ -1,0 +1,25 @@
+const parse = require('./script-parsers')
+const validateConfig = require('./validate-config')
+
+module.exports = function validateAllScripts(scripts, quiet) {
+  Object.keys(scripts).forEach(name => {
+    const script = scripts[name]
+    const webpackConfigFile = parse.webpackConfig(script)
+
+    if (script.indexOf('SET NODE_ENV=') === 0 || script.indexOf('NODE_ENV=') === 0) {
+      process.env.node_env = parse.nodeEnv(script)
+    } else {
+      process.env.npm_lifecycle_event = name
+    }
+
+    if (!quiet) console.info('\nValidating', name)
+    const validationResult = validateConfig(webpackConfigFile, quiet)
+
+    if (validationResult.error) {
+      console.info(validationResult.error.annotate())
+      process.exit(1)
+    } else {
+      if (!quiet) console.info(`${name} is valid`)
+    }
+  })
+}

--- a/src/bin/validate-config.js
+++ b/src/bin/validate-config.js
@@ -1,0 +1,17 @@
+const path = require('path')
+const validate = require('../')
+
+module.exports = function validateConfig(webpackConfigFile, quiet) {
+  if (!quiet) console.log(`Reading: ${webpackConfigFile}`)
+  const webpackConfigPath = path.join(process.cwd(), webpackConfigFile)
+
+  delete require.cache[
+    require.resolve(webpackConfigPath)
+  ]
+
+  const config = require(webpackConfigPath)
+  return validate(config, validate.schema, {
+    returnValidation: true,
+    quiet,
+  })
+}

--- a/src/bin/webpack-validator.js
+++ b/src/bin/webpack-validator.js
@@ -5,12 +5,13 @@ const fs = require('fs')
 const path = require('path')
 const program = require('commander')
 const log = require('npmlog')
-const validate = require('../')
-const schema = require('../').schema
+const validateAllScripts = require('./validate-all-scripts')
+const validateConfig = require('./validate-config')
 let configFile
 
 program
   .arguments('<configFileName>')
+  .option('-a, --all-scripts', 'Validate all configurations from package.json scripts')
   .option('-q, --quiet', 'Quiet output')
   .action((configFileName) => {
     configFile = configFileName
@@ -26,40 +27,40 @@ function errorHandler(err) {
   process.exit(1)
 }
 
-function validateConfig(webpackConfigFile, quiet) {
-  if (!quiet) console.log(`Reading: ${webpackConfigFile}`)
-  const config = require(path.join(process.cwd(), webpackConfigFile))
-  const validationResult = validate(config, schema, {
-    returnValidation: true,
-    quiet,
+function validateFile(config, quiet) {
+  fs.stat(configFile, (err, stats) => {
+    if (err) {
+      err.message = `Could not find file "${configFile}"` // eslint-disable-line no-param-reassign
+      errorHandler(err)
+    } else {
+      if (stats.isFile()) {
+        const validationResult = validateConfig(config, quiet)
+
+        if (validationResult.error) {
+          console.info(validationResult.error.annotate())
+          process.exit(1)
+        } else {
+          if (!quiet) console.info(`${config} is valid`)
+          process.exit(0)
+        }
+      } else {
+        const error = new Error(`Could not find file "${configFile}"`)
+        error.type = 'EISDIR'
+        errorHandler(error)
+      }
+    }
   })
-  if (validationResult.error) {
-    console.info(validationResult.error.annotate())
-    process.exit(1)
-  } else {
-    if (!quiet) console.info(`${webpackConfigFile} is valid`)
-    process.exit(0)
-  }
 }
 
-if (! configFile) {
+if (program.allScripts) {
+  const pkg = require(path.join(process.cwd(), './package.json'))
+
+  validateAllScripts(pkg.scripts, program.quiet)
+} else if (!configFile) {
   const error = new Error(['No configuration file given',
     'Usage: webpack-validator-cli <configFileName>'].join('\n'))
   error.type = 'EUSAGE'
   errorHandler(error)
+} else {
+  validateFile(configFile, program.quiet)
 }
-
-fs.stat(configFile, (err, stats) => {
-  if (err) {
-    err.message = `Could not find file "${configFile}"` // eslint-disable-line no-param-reassign
-    errorHandler(err)
-  } else {
-    if (stats.isFile()) {
-      validateConfig(configFile, program.quiet)
-    } else {
-      const error = new Error(`Could not find file "${configFile}"`)
-      error.type = 'EISDIR'
-      errorHandler(error)
-    }
-  }
-})


### PR DESCRIPTION
Now it's possible to execute `webpack-validator --all-scripts` (or just `-a`). After executing, *webpack-validator* will go through your **package.json** `scripts` and tries to validate each.

Closes #72.