### PR TITLE
feat(cli): Support webpack 2 --env

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "commander": "2.9.0",
     "joi": "8.0.5",
     "lodash": "4.11.1",
-    "npmlog": "2.0.3"
+    "npmlog": "2.0.3",
+    "yargs": "4.7.1"
   },
   "devDependencies": {
     "autoprefixer": "6.3.6",

--- a/src/bin/validate-config.js
+++ b/src/bin/validate-config.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const validate = require('../')
+const argv = require('yargs').argv
 
 module.exports = function validateConfig(webpackConfigFile, quiet) {
   if (!quiet) console.log(`Reading: ${webpackConfigFile}`)
@@ -10,7 +11,8 @@ module.exports = function validateConfig(webpackConfigFile, quiet) {
   ]
 
   const config = require(webpackConfigPath)
-  return validate(config, validate.schema, {
+  const configToValidate = typeof config === 'function' ? config(argv.env, argv) : config
+  return validate(configToValidate, validate.schema, {
     returnValidation: true,
     quiet,
   })


### PR DESCRIPTION
In webpack 2, your config can be a function that accepts the `env` flag
as parsed from [yargs][yargs] (see [here][webpack-usage]). This will
allow people to use the --env flag with the CLI for their Webpack 2
configs.

[yargs]: https://github.com/yargs/yargs
[webpack-usage]: https://github.com/webpack/webpack/blob/76e845914b5ff18de8d13a9c188666a60c736fd0/bin/convert-argv.js#L103