### PR TITLE
test: improve testing utils

### DIFF
--- a/src/properties/context/index.test.js
+++ b/src/properties/context/index.test.js
@@ -2,16 +2,11 @@ import schema from './index'
 import { allValid, allInvalid } from '../../../test/utils'
 
 const validModuleConfigs = [
-  // #0
   { input: 'exists' }, // Absolute
 ]
 
 const invalidModuleConfigs = [
-  // #0
-  // Relative
-  { input: './entry.js', error: { type: 'path.absolute' } },
-
-  // #1
+  { input: './entry.js', error: { type: 'path.absolute' } }, // Relative
   { input: 1, error: { message: '"value" must be a string' } },
 ]
 

--- a/src/properties/devServer/index.test.js
+++ b/src/properties/devServer/index.test.js
@@ -3,94 +3,50 @@ import { allValid, allInvalid } from '../../../test/utils'
 import { urlPart } from '../../types'
 
 const validModuleConfigs = [
-  // #0
   { input: { lazy: true } },
-  // #1
   { input: { inline: true } },
-  // #2
   { input: { stdin: true } },
-  // #2
   { input: { open: true } },
-  // #4
   { input: { info: true } },
-  // #5
   { input: { quiet: true } },
-  // #6
   { input: { https: true } },
-  // #7
   { input: { key: '/path/to/key' } },
-  // #8
   { input: { cert: 'path/to/cert' } },
-  // #9
   { input: { cacert: 'path/to/cacert' } },
-  // #10
   { input: { contentBase: '/content/base' } },
-  // #11
   { input: { contentBase: { target: '/content/base/' } } },
-  // #12
   { input: { contentBase: ['/content/base/'] } },
-  // #13
   { input: { historyApiFallback: true } },
-  // #14
   { input: { historyApiFallback: { index: '/foo-app/' } } },
-  // #15
   { input: { compress: true } },
-  // #16
   { input: { port: 3000 } },
-  // #17
   { input: { public: 'localhost' } },
-  // #18
   { input: { host: '0.0.0.0' } },
-  // #19
   { input: { publicPath: '/public/path/' } },
-  // #20
   { input: { publicPath: 'public/path/' } },
-  // #21
   { input: { outputPath: '/' } },
-  // #22
   { input: { filename: 'bundle.js' } },
-  // #23
   { input: { watchOptions: {} } },
-  // #24
   { input: { hot: true } },
-  // #25
   { input: { stats: {} } },
-  // #26
   { input: { stats: 'none' } },
-  // #27
   { input: { stats: 'errors-only' } },
-  // #28
   { input: { stats: 'minimal' } },
-  // #29
   { input: { stats: 'normal' } },
-  // #30
   { input: { stats: 'verbose' } },
-  // #31
   { input: { noInfo: true } },
-  // #32
   { input: { proxy: {} } },
-  // #33
-  { input: { proxy: 'http://proxy.url/' } },
-  // #34
   { input: { proxy: [] } },
-  // #35
   { input: { staticOptions: {} } },
-  // #36
   { input: { headers: {} } },
 ]
 
 const invalidModuleConfigs = [
-  // #0
   { input: { publicPath: 'public/path' }, error: { message: `"publicPath" ${urlPart.message}` } },
-  // #1
   { input: { outputPath: './output/path' }, error: { message: `"outputPath" ${urlPart.message}` } },
-  // #2
   { input: { watchOptions: true } },
-  // #3
   { input: { stats: true } },
-  // #4
   { input: { stats: 'foobar' } },
-  // #5
   { input: { proxy: true } },
 ]
 

--- a/src/properties/devtool/index.test.js
+++ b/src/properties/devtool/index.test.js
@@ -2,30 +2,19 @@ import schema from './index'
 import { allValid, allInvalid } from '../../../test/utils'
 
 const validModuleConfigs = [
-  // #0
   { input: 'eval' },
-  // #1
   { input: '#@eval' },
-  // #2
   { input: '#cheap-module-eval-source-map' },
-  // #3
   { input: 'hidden-source-map' },
-  // #4
   { input: 'inline-source-map' },
-  // #5
   { input: 'eval-source-map' },
-  // #6
   { input: 'cheap-source-map' },
 ]
 
 const invalidModuleConfigs = [
-  // #0
   { input: 'foo', error: { } },
-  // #1
   { input: 'eval-source-map-foo', error: { } },
-  // #2
   { input: 'foo-cheap-source-map', error: { } },
-  // #3
   { input: '#@eval-foo', error: { } },
 ]
 

--- a/src/properties/entry/index.test.js
+++ b/src/properties/entry/index.test.js
@@ -2,27 +2,15 @@ import schema from './index'
 import { allValid, allInvalid } from '../../../test/utils'
 
 const validModuleConfigs = [
-  // #0
   { input: './entry.js' },
-
-  // #1
   { input: ['./entry.js'] },
-
-  // #2
   { input: { foo: './entry.js', bar: ['./bar.js'] } },
 ]
 
 const invalidModuleConfigs = [
-  // #0
   { input: 1, error: { message: '"value" must be a string' } },
-
-  // #1
   { input: [1], error: { message: '"0" must be a string' } },
-
-  // #2
   { input: [1, 'foo'], error: { message: '"0" must be a string' } },
-
-  // #3
   { input: { foo: 1, bar: ['./bar.js'] }, error: { message: '"value" must be a string' } },
 ]
 

--- a/src/properties/externals/index.test.js
+++ b/src/properties/externals/index.test.js
@@ -2,14 +2,10 @@ import schema, { EXTERNALS_MESSAGE } from './index'
 import { allValid, allInvalid } from '../../../test/utils'
 
 const validModuleConfigs = [
-  // #0
   { input: 'dependency' },
-
-  // #1
   { input: ['dependency'] },
-
-  // #2 ( from https://webpack.github.io/docs/configuration.html#externals )
   {
+    // from https://webpack.github.io/docs/configuration.html#externals )
     input: {
       a: false,
       b: true,
@@ -17,8 +13,6 @@ const validModuleConfigs = [
       './d': 'var d',
     },
   },
-
-  // #3 ( from real life )
   {
     input: [
       {
@@ -32,16 +26,11 @@ const validModuleConfigs = [
       },
     ],
   },
-
-  // #4
   { input: /dependency/ },
-
-  // #5
   { input: (a, b, c) => { } }, // eslint-disable-line
 ]
 
 const invalidModuleConfigs = [
-  // #0
   {
     input: {
       a: ['foo'],
@@ -51,8 +40,6 @@ const invalidModuleConfigs = [
     },
     error: { message: `"value" ${EXTERNALS_MESSAGE}` },
   },
-
-  // #1
   {
     input: [{
       a: ['foo'],
@@ -62,16 +49,12 @@ const invalidModuleConfigs = [
     }],
     error: { message: `"value" ${EXTERNALS_MESSAGE}` },
   },
-
-  // #2
   {
     input: 1,
     error: { message: `"value" ${EXTERNALS_MESSAGE}` },
   },
-
-  // #3
-  // Only 3-arity allowed
   {
+    // Only 3-arity allowed
     input: (a, b, c, d) => { }, // eslint-disable-line
     error: { message: `"value" ${EXTERNALS_MESSAGE}` },
   },

--- a/src/properties/module/index.test.js
+++ b/src/properties/module/index.test.js
@@ -2,7 +2,6 @@ import moduleSchema, { CONDITION_MESSAGE, LOADERS_QUERY_MESSAGE } from './index'
 import { allValid, allInvalid } from '../../../test/utils'
 
 const validModuleConfigs = [
-  // #0
   {
     input: {
       loaders: [
@@ -10,7 +9,6 @@ const validModuleConfigs = [
       ],
     },
   },
-  // #1
   {
     input: {
       loaders: [
@@ -18,7 +16,6 @@ const validModuleConfigs = [
       ],
     },
   },
-  // #2
   {
     input: {
       loaders: [
@@ -26,7 +23,6 @@ const validModuleConfigs = [
       ],
     },
   },
-  // #3
   {
     input: {
       loaders: [
@@ -34,7 +30,6 @@ const validModuleConfigs = [
       ],
     },
   },
-  // #4
   {
     input: {
       loaders: [
@@ -45,7 +40,6 @@ const validModuleConfigs = [
 ]
 
 const invalidModuleConfigs = [
-  // #0
   {
     input: {
       loaders: [
@@ -54,7 +48,6 @@ const invalidModuleConfigs = [
     },
     error: { message: '"test" is required' },
   },
-  // #1
   {
     input: {
       loaders: [
@@ -63,7 +56,6 @@ const invalidModuleConfigs = [
     },
     error: { message: `"include" ${CONDITION_MESSAGE}` },
   },
-  // #2
   {
     input: {
       loaders: [
@@ -72,7 +64,6 @@ const invalidModuleConfigs = [
     },
     error: { message: '"loaders" must be an array' },
   },
-  // #3
   {
     input: {
       loaders: [
@@ -81,21 +72,18 @@ const invalidModuleConfigs = [
     },
     error: { message: '"0" must be a string', path: 'loaders.0.loaders.0' },
   },
-  // #4
   {
     input: {
       loaders: [{ test: /\.(?:eot|ttf|woff2?)$/, loader: ['file-loader'] }],
     },
     error: { message: '"loader" must be a string' },
   },
-  // #5
   {
     input: {
       loaders: [{ test: /\.(?:eot|ttf|woff2?)$/, loaders: ['file-loader'], loader: 'style' }],
     },
     error: { message: '"value" contains a conflict between exclusive peers [loaders, loader]' },
   },
-  // #6
   {
     input: {
       loaders: [{ test: (foo, bar) => `${foo}-${bar}`, loaders: ['file-loader'] }],
@@ -103,7 +91,6 @@ const invalidModuleConfigs = [
     // Only 1-arity functions are allowed
     error: { message: `"test" ${CONDITION_MESSAGE}` },
   },
-  // #7
   {
     input: {
       loaders: [{ query: { foo: 'bar' }, loaders: ['file-loader'], test: /foo/ }],
@@ -111,14 +98,12 @@ const invalidModuleConfigs = [
     // query can only be supplied when `loader` property is supplied
     error: { message: `"value" ${LOADERS_QUERY_MESSAGE}` },
   },
-  // #8
   {
     input: {
       loaders: [{ test: /foo/ }],
     },
     error: { message: '"value" must contain at least one of [loaders, loader]' },
   },
-  // #9
   {
     input: {
       loaders: [{ test: /foo/, loader: 'foo', query: 'query' }],

--- a/src/properties/node/index.test.js
+++ b/src/properties/node/index.test.js
@@ -2,33 +2,16 @@ import schema from './index'
 import { allValid, allInvalid } from '../../../test/utils'
 
 const validModuleConfigs = [
-  // #0
   { input: { console: true } },
-
-  // #1
   { input: { global: true } },
-
-  // #2
   { input: { Buffer: true } },
-
-  // #3
   { input: { process: 'mock' } },
-
-  // #4
   { input: { __filename: true } },
-
-  // #5
   { input: { __dirname: false } },
-
-  // #6
   { input: { foo: 'mock' } },
 ]
 
 const invalidModuleConfigs = [
-  // #0
-  // { input: { foo: 'mocka' }, error: { } },
-
-  // #0
   { input: [1], error: { } },
 ]
 

--- a/src/properties/output/index.test.js
+++ b/src/properties/output/index.test.js
@@ -3,120 +3,66 @@ import { allValid, allInvalid } from '../../../test/utils'
 import { notAbsolutePath, urlPart } from '../../types'
 
 const validModuleConfigs = [
-  // #0
   { input: { filename: 'foo' } },
-  // #1
   { input: { chunkFilename: 'foo' } },
-  // #2
   { input: { path: 'exists' } },
-  // #3
   { input: { publicPath: '/assets/' } },
-  // #4
-  { input: { publicPath: 'http://cdn.example.com/assets/[hash]/' } },
-  // #5
-  { input: { devtoolModuleFilenameTemplate: 'webpack:///[resourcePath]?[hash]' } },
-  // #6
   { input: { devtoolModuleFilenameTemplate: () => {} } },
-  // #7
   { input: { hotUpdateChunkFilename: '[id].[hash].hot-update.js' } },
-  // #8
   { input: { hotUpdateMainFilename: '[hash].hot-update.json' } },
-  // #9
   { input: { jsonpFunction: 'webpackJsonp' } },
-  // #10
   { input: { hotUpdateFunction: 'webpackHotUpdate' } },
-  // #11
   { input: { pathinfo: false } },
-  // #12
   { input: { library: 'redux' } },
-  // #13
   { input: { library: ['redux', '[name]'] } },
-  // #14
   { input: { libraryTarget: 'commonjs' } },
-  // #15
   { input: { crossOriginLoading: false } },
-  // #16
   { input: { crossOriginLoading: 'anonymous' } },
-  // #17
   { input: { crossOriginLoading: 'anonymous' } },
-  // #18
-  { input: { hashDigestLength: 6 } }, // undocumented
-  // #19
   { input: { publicPath: '' } },
 ]
 
 const invalidModuleConfigs = [
-  // #0
   {
-    input: {
-      filename: '/foo/bar',
-    },
+    input: { filename: '/foo/bar' },
     error: { message: `"filename" ${notAbsolutePath.message}` },
   },
-  // #1
   {
-    input: {
-      chunkFilename: '/foo/bar',
-    },
+    input: { chunkFilename: '/foo/bar' },
     error: { message: `"chunkFilename" ${notAbsolutePath.message}` },
   },
-  // #2
   {
-    input: {
-      path: './foo/bar',
-    },
+    input: { path: './foo/bar' },
     error: { type: 'path.absolute' },
   },
-  // #3
   {
-    input: {
-      publicPath: './foo',
-    },
+    input: { publicPath: './foo' },
     error: { message: `"publicPath" ${urlPart.message}` },
   },
-  // #4
   {
-    input: {
-      publicPath: '/foo',
-    },
+    input: { publicPath: '/foo' },
     error: { message: `"publicPath" ${urlPart.message}` },
   },
-  // #5
   {
-    input: {
-      devtoolModuleFilenameTemplate: '/foo',
-    },
+    input: { devtoolModuleFilenameTemplate: '/foo' },
     error: { message: `"devtoolModuleFilenameTemplate" ${notAbsolutePath.message}` },
   },
-  // #6
   {
-    input: {
-      libraryTarget: 'comonjs',
-    },
+    input: { libraryTarget: 'comonjs' },
     error: { message: '"libraryTarget" must be one of [var, this, commonjs, commonjs2, amd, umd]' },
   },
-  // #6
   {
-    input: {
-      crossOriginLoading: 'annonymous',
-    },
+    input: { crossOriginLoading: 'annonymous' },
     error: { message: '"crossOriginLoading" should be `false`, "anonymous" or "use-credentials"' },
   },
-  // #7
   {
-    input: {
-      fileName: 'foo',
-    },
+    input: { fileName: 'foo' },
     error: { message: '"fileName" is not allowed' },
   },
-  // #8
   {
-    input: {
-      fileName: 'foo',
-    },
+    input: { fileName: 'foo' },
     error: { message: '"fileName" is not allowed' },
   },
-  // #9
   { input: { library: ['redux', 1] } },
 
 ]

--- a/src/properties/plugins/index.test.js
+++ b/src/properties/plugins/index.test.js
@@ -2,7 +2,6 @@ import schema from './index'
 import { allValid, allInvalid } from '../../../test/utils'
 
 const validModuleConfigs = [
-  // #0
   {
     input: [
       () => {},
@@ -12,7 +11,6 @@ const validModuleConfigs = [
 ]
 
 const invalidModuleConfigs = [
-  // #0
   { input: 1, error: { } },
 ]
 

--- a/src/properties/resolve/index.test.js
+++ b/src/properties/resolve/index.test.js
@@ -12,43 +12,18 @@ const problematicRootPaths = [
   path.join(__dirname, './exists-with-node-modules/node_modules'),
 ]
 const validModuleConfigs = [
-  // #0
   { input: { alias: { foo: 'bar' } } },
-
-  // #1
   { input: { alias: { foo: 'bar' } } },
-
-  // #2
   { input: { root: 'exists' } },
-
-  // #3
   { input: { root: ['exists', 'exists'] } },
-
-  // #4
   { input: { modulesDirectories: ['node_modules', 'bower_foo'] } },
-
-  // #5
   { input: { fallback: ['exists', 'exists'] } },
-
-  // #6
   { input: { extensions: ['', '.foo'] } },
-
-  // #7
   { input: { packageMains: ['webpack', 'browser', 'web', 'browserify', ['jam', 'main'], 'main'] } },
-
-  // #8
   { input: { packageAlias: 'browser' } },
-
-  // #9
   { input: { unsafeCache: [/foo/] } },
-
-  // #10
   { input: { unsafeCache: /foo/ } },
-
-  // #11
   { input: { unsafeCache: true } },
-
-  // #12 (Ok when rule disabled)
   {
     input: {
       // These won't throw however because we disabled the rule
@@ -59,48 +34,20 @@ const validModuleConfigs = [
 ]
 
 const invalidModuleConfigs = [
-  // #0
-  {
-    input: { alias: { foo: 1 } },
-  },
-
-  // #1
-  {
-    input: { alias: ['foo'] },
-  },
-
-  // #2
+  { input: { alias: { foo: 1 } } },
+  { input: { alias: ['foo'] } },
   {
     // It exists but is not absolute
     // file existence stubbed out in test/setup.js
     input: { root: './exists' },
     schema: schemaFn({ rules: { 'no-root-files-node-modules-nameclash': false } }),
   },
-
-  // #3
+  { input: { root: '/does-not-exist' } }, // must exist
+  { input: { modulesDirectories: 'node_modules' } },
+  { input: { extensions: ['', 'bar'] } }, // must have leading dot
+  { input: { unsafeCache: false } }, // must have true
   {
-    input: { root: '/does-not-exist' }, // must exist
-  },
-
-  // #4
-  {
-    input: { modulesDirectories: 'node_modules' },
-  },
-
-  // #5
-  {
-    input: { extensions: ['', 'bar'] }, // must have leading dot
-  },
-
-  // #6
-  {
-    input: { unsafeCache: false }, // must have true
-  },
-  // #7
-  {
-    input: {
-      root: problematicRootPaths,
-    },
+    input: { root: problematicRootPaths },
     error: { type: 'path.noRootFilesNodeModulesNameClash' },
   },
 ]

--- a/src/properties/target/index.test.js
+++ b/src/properties/target/index.test.js
@@ -2,12 +2,10 @@ import schema from './index'
 import { allValid, allInvalid } from '../../../test/utils'
 
 const validConfigs = [
-  // #0
   { input: 'web' },
 ]
 
 const invalidConfigs = [
-  // #0
   {
     input: 'foo',
     error: {

--- a/src/properties/watchOptions/index.test.js
+++ b/src/properties/watchOptions/index.test.js
@@ -2,13 +2,9 @@ import schema from './index'
 import { allValid } from '../../../test/utils'
 
 const validModuleConfigs = [
-  // #0
   { input: { aggregateTimeout: 300 } },
-  // #1
   { input: { poll: true } },
-  // #2
   { input: { poll: false } },
-  // #3
   { input: { poll: 1000 } },
 ]
 

--- a/test/utils/allInvalid.js
+++ b/test/utils/allInvalid.js
@@ -1,4 +1,6 @@
 import validate from '../../src/index'
+import chalk from 'chalk'
+import util from 'util'
 
 /**
  * For all supplied configs (array of objects), check that they are invalid given a schema.
@@ -14,8 +16,8 @@ export default (configs, schema) => {
     throwError = false,
     // Override the schema in order to test for non-default rule configurations
     schema: schemaOverride,
-  }, n) => {
-    it(`invalid #${n} should be invalid`, () => {
+  }) => {
+    it(`: ${chalk.gray(util.inspect(invalidConfig, false, null))} should be invalid`, () => {
       if (!invalidConfig) {
         throw new Error('Pass data as `input` property')
       }

--- a/test/utils/allValid.js
+++ b/test/utils/allValid.js
@@ -1,10 +1,12 @@
 import validate from '../../src/index'
+import chalk from 'chalk'
+import util from 'util'
 
 /**
  * For all supplied configs (array of objects), check that they are valid given a schema.
  */
 export default (configs, schema) => {
-  configs.forEach((input, n) => {
+  configs.forEach((input) => {
     const { input: validConfig, schema: schemaOverride } = input
     if (!validConfig) {
       throw new Error(
@@ -13,7 +15,7 @@ export default (configs, schema) => {
       )
     }
 
-    it(`valid #${n} should be valid`, () => {
+    it(`: ${chalk.gray(util.inspect(validConfig, false, null))} should be valid`, () => {
       const result = validate(validConfig, {
         schema: schemaOverride || schema,
         returnValidation: true,


### PR DESCRIPTION
This is inspired by a comment from @bebraw asking why we need those "#<number" comments all over the place. The reason for this is that the test utils `allValid` and `allInvalid` create test case descriptions (`it("...")`) by using the array index of the given case. In order to find a failing test case, the comments would be necessary. It's kinda awkward. So what about the putting the whole stringified config slice into the test description, like this:
![better-test-failures](https://cloud.githubusercontent.com/assets/3755413/15442269/39b0a034-1ee0-11e6-8c38-372db3f8970b.png)

What do you think? I'd like this as it's cumbersome to shift test cases around, forcing you to change the numbering each time. This implementation is much clearer I think.
If you like it, i'll remove the number comments before we merge this PR.