### PR TITLE
fix: adapt validate() examples to v2 api

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Some validations do more than just validating your data shape, they check for be
 - **no-root-files-node-modules-nameclash** (default: true): this checks that files/folders that are found in directories specified via webpacks `resolve.root` option do not nameclash with `node_modules` packages. This prevents nasty path resolving bugs (for a motivating example, have a look at [this redux issue](https://github.com/reactjs/redux/issues/1681)).
 
 You opt in/out of rules by using the `rules` option:
-```
+```js
 module.exports = validate(config, {
   rules: {
     'no-root-files-node-modules-nameclash': false,
@@ -92,13 +92,13 @@ module.exports = validate(config, {
 **Note**: This is not yet implemented via cli options, the default rules will apply in that case.
 
 #### Quiet Mode
-If you want to mute console output apart from errors, set `--quiet` (`-q`) or `validate(config, yourSchema, {quiet: true})`. This is particularly useful if you are using webpack `--json` as you'll want to avoid writing additional text to the JSON output.
+If you want to mute console output apart from errors, set `--quiet` (`-q`) or `validate(config, { quiet: true })`. This is particularly useful if you are using webpack `--json` as you'll want to avoid writing additional text to the JSON output.
 
-#### Validate All **package.json** `scripts`
+#### Validate all **package.json** `scripts`
 It is possible to use the CLI to validate all your **package.json** `scripts` related configurations at once by using `--all-scripts` (`-a`). The system will try to guess the convention you are using and then executes validation against each script target based on that.
 
 #### Advanced Usage
-If you need to access the validation results directly and want to control the side-effects (i.e. console.log output, `process.exit(1)` on fail behaviour) yourself, you can call the validation function like so: `validate(config, yourSchema, { returnValidation: true })`. This will make 1) the function return the validation results instead of your configuration and 2) not perform any side effects.
+If you need to access the validation results directly and want to control the side-effects (i.e. console.log output, `process.exit(1)` on fail behaviour) yourself, you can call the validation function like so: `validate(config, { returnValidation: true })`. This will make 1) the function return the validation results instead of your configuration and 2) not perform any side effects.
 
 #### Support
 Because this module uses the amazing `Joi` validation library, this module only supports Node >=4.0.0.


### PR DESCRIPTION
oops, forgot about these.