### PR TITLE
fix(output.path): do not check output.path for file existence

### DIFF
--- a/src/properties/output/index.js
+++ b/src/properties/output/index.js
@@ -1,9 +1,10 @@
 import Joi from 'joi'
-import { notAbsolutePath, absolutePath, urlPart } from '../../types'
+import { notAbsolutePath, looksLikeAbsolutePath, urlPart } from '../../types'
 
 export default Joi.object({
   filename: notAbsolutePath,
-  path: absolutePath,
+  // don't check for existence here because it could be created in the build process
+  path: looksLikeAbsolutePath,
   publicPath: Joi.alternatives().try([
     urlPart,
     Joi.string().valid(''),

--- a/src/properties/output/index.test.js
+++ b/src/properties/output/index.test.js
@@ -6,6 +6,8 @@ const validModuleConfigs = [
   { input: { filename: 'foo' } },
   { input: { chunkFilename: 'foo' } },
   { input: { path: 'exists' } },
+  // Does not start with ./ or ../ so it "looks like an absolute path"
+  { input: { path: 'doesnt_actually' } },
   { input: { publicPath: '/assets/' } },
   { input: { devtoolModuleFilenameTemplate: () => {} } },
   { input: { hotUpdateChunkFilename: '[id].[hash].hot-update.js' } },

--- a/src/types/absolutePath.js
+++ b/src/types/absolutePath.js
@@ -14,9 +14,13 @@ export const JoiWithPath = Joi.extend({
     {
       name: 'absolute',
 
+      params: {
+        checkForExistence: Joi.bool(),
+      },
+
       validate(params, value, state, options) {
         const looksLikeAbsolutePath = /^(?!\.?\.\/).+$/.test(value)
-        const directoryExists = shell.test('-d', value)
+        const directoryExists = params.checkForExistence === false ? true : shell.test('-d', value)
         if (!looksLikeAbsolutePath || !directoryExists) {
           return this.createError('path.absolute', {
             path: value,
@@ -33,6 +37,7 @@ export const JoiWithPath = Joi.extend({
   ],
 })
 
-const absolutePath = JoiWithPath.path().absolute()
+const absolutePath = JoiWithPath.path().absolute(true)
 absolutePath.message = MESSAGE
 export default absolutePath
+export const looksLikeAbsolutePath = JoiWithPath.path().absolute(false)

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -1,3 +1,3 @@
-export { default as absolutePath } from './absolutePath'
+export { default as absolutePath, looksLikeAbsolutePath } from './absolutePath'
 export { default as notAbsolutePath } from './notAbsolutePath'
 export { default as urlPart } from './urlPart'


### PR DESCRIPTION
Fixes #102. I'll merge this right away as it breaks our build process at work as well. :D 