### PR TITLE
fix(devtool): add missing devtool options #113

### DIFF
--- a/src/properties/devtool/index.js
+++ b/src/properties/devtool/index.js
@@ -1,11 +1,15 @@
 import Joi from 'joi'
 
 const options = [
-  'eval',
-  'cheap-eval-source-map',
   'cheap-source-map',
-  'cheap-module-eval-source-map',
+  'cheap-eval-source-map',
+  'cheap-hidden-source-map',
+  'cheap-inline-source-map',
   'cheap-module-source-map',
+  'cheap-module-eval-source-map',
+  'cheap-module-hidden-source-map',
+  'cheap-module-inline-source-map',
+  'eval',
   'eval-source-map',
   'source-map',
   'hidden-source-map',

--- a/src/properties/devtool/index.test.js
+++ b/src/properties/devtool/index.test.js
@@ -5,10 +5,12 @@ const validModuleConfigs = [
   { input: 'eval' },
   { input: '#@eval' },
   { input: '#cheap-module-eval-source-map' },
+  { input: '#cheap-module-inline-source-map' },
   { input: 'hidden-source-map' },
   { input: 'inline-source-map' },
   { input: 'eval-source-map' },
   { input: 'cheap-source-map' },
+  { input: 'hidden-source-map' },
 ]
 
 const invalidModuleConfigs = [
@@ -22,4 +24,3 @@ describe('devtool', () => {
   allValid(validModuleConfigs, schema)
   allInvalid(invalidModuleConfigs, schema)
 })
-


### PR DESCRIPTION
Add missing webpack devtool combinations i.e. #cheap-module-eval-inline-source-map