### PR TITLE
fix: support webpack multi-compiler

### DIFF
--- a/src/bin/validate-config.js
+++ b/src/bin/validate-config.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const validate = require('../')
+const validate = require('../index').validateRoot
 const argv = require('yargs').argv
 
 module.exports = function validateConfig(webpackConfigFile, quiet) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,7 +1,9 @@
 import sinon from 'sinon'
 import configs from '../test/passing-configs'
 import failingConfigs from '../test/failing-configs'
-import validate, { Joi } from './'
+import { Joi } from './'
+
+const validate = require('./index').validateRoot
 
 describe('.', () => {
   let sandbox

--- a/test/passing-configs/webpack-multi-compiler.js
+++ b/test/passing-configs/webpack-multi-compiler.js
@@ -1,0 +1,35 @@
+/**
+ *
+ * @link https://github.com/webpack/webpack/blob/master/examples/multi-compiler/webpack.config.js
+ *
+ */
+
+var path = require("path");
+var webpack = require('webpack')
+
+module.exports = [
+  {
+    entry: "./example",
+    output: {
+      path: path.join(__dirname, "js"),
+      filename: "mobile.js"
+    },
+    plugins: [
+      new webpack.DefinePlugin({
+        ENV: JSON.stringify("mobile")
+      })
+    ]
+  },
+  {
+    entry: "./example",
+    output: {
+      path: path.join(__dirname, "js"),
+      filename: "desktop.js"
+    },
+    plugins: [
+      new webpack.DefinePlugin({
+        ENV: JSON.stringify("desktop")
+      })
+    ]
+  }
+];

--- a/test/utils/allInvalid.js
+++ b/test/utils/allInvalid.js
@@ -1,7 +1,6 @@
 import chalk from 'chalk'
 import util from 'util'
-
-const validate = require('../../src/index').validate
+import { validate } from '../../src'
 
 /**
  * For all supplied configs (array of objects), check that they are invalid given a schema.

--- a/test/utils/allInvalid.js
+++ b/test/utils/allInvalid.js
@@ -1,6 +1,7 @@
-import validate from '../../src/index'
 import chalk from 'chalk'
 import util from 'util'
+
+const validate = require('../../src/index').validate
 
 /**
  * For all supplied configs (array of objects), check that they are invalid given a schema.

--- a/test/utils/allValid.js
+++ b/test/utils/allValid.js
@@ -1,7 +1,6 @@
 import chalk from 'chalk'
 import util from 'util'
-
-const validate = require('../../src/index').validate
+import { validate } from '../../src'
 
 /**
  * For all supplied configs (array of objects), check that they are valid given a schema.

--- a/test/utils/allValid.js
+++ b/test/utils/allValid.js
@@ -1,6 +1,7 @@
-import validate from '../../src/index'
 import chalk from 'chalk'
 import util from 'util'
+
+const validate = require('../../src/index').validate
 
 /**
  * For all supplied configs (array of objects), check that they are valid given a schema.


### PR DESCRIPTION
when provided with an array of configurations, iterate array and validate each configuration
individually

fixes #117