### PR TITLE
Allow `false` as "devtool" value

### DIFF
--- a/src/properties/devtool/index.js
+++ b/src/properties/devtool/index.js
@@ -22,6 +22,7 @@ const DEVTOOL_REGEX = new RegExp(
   `(${options.join('$|')})` // one of the options
 )
 
-export default Joi
-  .string()
-  .regex(DEVTOOL_REGEX)
+export default [
+  Joi.string().regex(DEVTOOL_REGEX),
+  Joi.any().valid(false),
+]

--- a/src/properties/devtool/index.test.js
+++ b/src/properties/devtool/index.test.js
@@ -11,6 +11,7 @@ const validModuleConfigs = [
   { input: 'eval-source-map' },
   { input: 'cheap-source-map' },
   { input: 'hidden-source-map' },
+  { input: false },
 ]
 
 const invalidModuleConfigs = [
@@ -18,6 +19,8 @@ const invalidModuleConfigs = [
   { input: 'eval-source-map-foo', error: { } },
   { input: 'foo-cheap-source-map', error: { } },
   { input: '#@eval-foo', error: { } },
+  { input: 'false', error: { } },
+  { input: true, error: { } },
 ]
 
 describe('devtool', () => {

--- a/test/utils/allValid.js
+++ b/test/utils/allValid.js
@@ -7,13 +7,14 @@ import validate from '../../src'
  */
 export default (configs, schema) => {
   configs.forEach((input) => {
-    const { input: validConfig, schema: schemaOverride } = input
-    if (!validConfig) {
+    if (!Object.prototype.hasOwnProperty.call(input, 'input')) {
       throw new Error(
         'Please supply the valid config object like `{ input: <valid-config-object> }`.' +
         `You passed ${JSON.stringify(input)}`
       )
     }
+
+    const { input: validConfig, schema: schemaOverride } = input
 
     it(`: ${chalk.gray(util.inspect(validConfig, false, null))} should be valid`, () => {
       const result = validate(validConfig, {


### PR DESCRIPTION
In webpack config it's also possible to disable sourcemaps by providing `false` to `devtool`. It's also a default value: https://github.com/webpack/webpack/blob/40aac864fd88495cd56dbec9bab522f8f34a47ea/lib/WebpackOptionsDefaulter.js#L11

It's useful, for example for this:
```js
{
  devtool: isProd ? false : 'eval'
}
```

This PR adds `false` as a valid value for `devtool`.