### PR TITLE
cross-env upgraded

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "chalk": "1.1.3",
     "commander": "2.9.0",
     "common-tags": "0.1.1",
-    "cross-env": "^1.0.7",
+    "cross-env": "^3.1.1",
     "find-node-modules": "^1.0.1",
     "joi": "9.0.0-0",
     "lodash": "4.11.1",


### PR DESCRIPTION
Old version of cross-env brings transitively lodash.assign which is deprecated and causes warning during `npm install` (both on this project and on all projects using webpack-validator)

```
$ npm install
npm WARN deprecated lodash.assign@4.2.0: This package is deprecated. Use Object.assign.
```