### PR TITLE
fix(devServer): add setup property to devServer options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.idea/*
 .nyc_output/
 coverage/
 *.log

--- a/src/properties/devServer/index.js
+++ b/src/properties/devServer/index.js
@@ -46,6 +46,7 @@ export default Joi.object({
     Joi.array(),
     Joi.string(),
   ],
+  setup: Joi.func().arity(1),
   staticOptions: Joi.object(),
   headers: Joi.object(),
 })

--- a/src/properties/devServer/index.test.js
+++ b/src/properties/devServer/index.test.js
@@ -40,6 +40,7 @@ const validModuleConfigs = [
   { input: { noInfo: true } },
   { input: { proxy: {} } },
   { input: { proxy: [] } },
+  { input: { setup: (a) => {} } }, // eslint-disable-line
   { input: { staticOptions: {} } },
   { input: { headers: {} } },
   { input: { localAddress: '1.2.3.4:30' } },
@@ -53,6 +54,7 @@ const invalidModuleConfigs = [
   { input: { stats: true } },
   { input: { stats: 'foobar' } },
   { input: { proxy: true } },
+  { input: { setup: (a, b) => {} } }, // eslint-disable-line
   { input: { localAddress: '1.2.3.4' } },
   { input: { logLevel: 'insane' } },
 ]


### PR DESCRIPTION
Add missing setup property to devServer options.
See https://webpack.github.io/docs/webpack-dev-server.html#api for setup
option

Close #143