### PR TITLE
feat: Allow performance.hints in webpack config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import resolveSchemaFn from './properties/resolve'
 import outputSchema from './properties/output'
 import watchOptionsSchema from './properties/watchOptions'
 import devServerSchema from './properties/devServer'
+import performanceSchema from './properties/performance'
 import { looksLikeAbsolutePath } from './types'
 import _merge from 'lodash/merge'
 import sh from 'shelljs'
@@ -55,6 +56,7 @@ function makeSchema(schemaOptions, schemaExtension) {
     })),
     watch: Joi.boolean(),
     watchOptions: watchOptionsSchema,
+    performance: performanceSchema,
     stats: Joi.any(), // TODO
     target: Joi.any(), // TODO
 

--- a/src/properties/performance/index.js
+++ b/src/properties/performance/index.js
@@ -1,0 +1,5 @@
+import Joi from 'joi'
+
+export default Joi.object({
+  hints: Joi.boolean(),
+})

--- a/src/properties/performance/index.test.js
+++ b/src/properties/performance/index.test.js
@@ -1,5 +1,5 @@
 import schema from './index'
-import { allValid } from '../../../test/Utils'
+import { allValid } from '../../../test/utils'
 
 const validPerformanceConfigs = [
   { input: { hints: true } },

--- a/src/properties/performance/index.test.js
+++ b/src/properties/performance/index.test.js
@@ -1,0 +1,11 @@
+import schema from './index'
+import { allValid } from '../../../test/Utils'
+
+const validPerformanceConfigs = [
+  { input: { hints: true } },
+  { input: { hints: false } },
+]
+
+describe('performance', () => {
+  allValid(validPerformanceConfigs, schema)
+})


### PR DESCRIPTION
Webpack 2.1.0-beta.28 adds `performance.hints` (which take boolean values) as a way to enable/disable performance warnings. (The first performance warning is about bundle size.)